### PR TITLE
Apply latest rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Naming/FileName:
+  Enabled: false
+
 Style/BlockDelimiters:
   Exclude:
     - spec/**/*

--- a/lib/jekyll-lazy-load-image/config.rb
+++ b/lib/jekyll-lazy-load-image/config.rb
@@ -11,6 +11,7 @@ module JekyllLazyLoadImage
 
     def owners=(value)
       return if value.nil? || value.empty?
+
       @owners = Array(value).map(&:to_sym).tap do |owners_prospective|
         not_allowed_hooks = ALLOWED_JEKYLL_HOOK_CONTAINERS & owners_prospective
         raise ArgumentError, "The owners option must be #{ALLOWED_JEKYLL_HOOK_CONTAINERS.join(" or ")}." if not_allowed_hooks.size.zero?

--- a/lib/jekyll-lazy-load-image/translator.rb
+++ b/lib/jekyll-lazy-load-image/translator.rb
@@ -12,6 +12,7 @@ module JekyllLazyLoadImage
     def translate
       nokogiri_doc.xpath("//img").each do |node|
         next if ignore_node?(node)
+
         apply_lazy_image_setting(node)
         inject_class_attr(node)
         inject_additional_attrs(node)


### PR DESCRIPTION
`rubocop`
 
- changed `Naming/FileName` behavior
- automatically applied `Layout/EmptyLineAfterGuardClause`.

https://github.com/rubocop-hq/rubocop/releases/tag/v0.59.0
