### PR TITLE
Upgrade bundler to v2

### DIFF
--- a/jekyll-lazy-load-image.gemspec
+++ b/jekyll-lazy-load-image.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "jekyll", "~> 3.8"
   spec.add_dependency "nokogiri", "~> 1.8"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0"
 end


### PR DESCRIPTION
The bundler was upgraded to v2.
And we use it with only development in this project.

Therefore, I will upgrade bundler version.