### PR TITLE
weak jekyll version dependency

### DIFF
--- a/jekyll-lazy-load-image.gemspec
+++ b/jekyll-lazy-load-image.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "jekyll", ">= 3.8", "< 5.0"
+  spec.add_dependency "jekyll", "~> 3.8", "< 5.0"
   spec.add_dependency "nokogiri", "~> 1.8"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
Improve the version dependencies lock down caused installation failure with newer version of Jekyll.