### PR TITLE
move before install to top

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@
 language: ruby
 sudo: false
 cache: bundler
+before_install:
+  - gem update bundler
 jobs:
   include:
     - &test
       stage: test
       rvm: 2.4.9
-      before_install:
-        - gem update bundler
       script:
         - bundle exec rubocop
         - bundle exec rake spec


### PR DESCRIPTION
Since `before_install` during CI is common to all jobs, it has been moved to top.