### PR TITLE
FIX jekyll dependences

### DIFF
--- a/jekyll-lazy-load-image.gemspec
+++ b/jekyll-lazy-load-image.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_dependency "jekyll", "~> 3.8", "< 5.0"
+  spec.add_dependency "jekyll", ">= 3.8"
   spec.add_dependency "nokogiri", "~> 1.8"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
I thought https://github.com/kenchan0130/jekyll-lazy-load-image/pull/11 solve by https://github.com/kenchan0130/jekyll-lazy-load-image/issues/10. But this was my misunderstanding.

Since the 5.0 restriction is not necessary, I returned it to the withdrawal source.

FIX: #10