### PR TITLE
Drop ruby 2.4 and 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - bin/**/*
     - exe/**/*

--- a/jekyll-lazy-load-image.gemspec
+++ b/jekyll-lazy-load-image.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "jekyll", ">= 3.8"
   spec.add_dependency "nokogiri", "~> 1.8"


### PR DESCRIPTION
Ruby 2.4 and 2.5 have already reached its EOL.
Therefore, this library supports 2.6 or later